### PR TITLE
fix: list all owned book types in ddb_list_library

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -183,7 +183,7 @@ server.tool("ddb_search", "Search D&D Beyond for spells, monsters, magic items, 
     }
 });
 // ─── ddb_list_library ─────────────────────────────────────────────────────────
-server.tool("ddb_list_library", "List all books and sourcebooks you own in your D&D Beyond library.", {}, async () => {
+server.tool("ddb_list_library", "List all books you own in your D&D Beyond library, including sourcebooks, adventures, and supplements.", {}, async () => {
     try {
         const context = await getSharedContext();
         const books = await listLibrary(context);

--- a/dist/tools/library.js
+++ b/dist/tools/library.js
@@ -4,7 +4,7 @@ export async function listLibrary(context) {
     if (!(await isLoggedIn(page))) {
         throw new Error("Not logged in. Please run ddb_login first.");
     }
-    await page.goto("https://www.dndbeyond.com/en/library?type=sourcebooks&ownership=owned-shared", {
+    await page.goto("https://www.dndbeyond.com/en/library?ownership=owned-shared", {
         waitUntil: "networkidle",
         timeout: 30000,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,7 @@ server.tool(
 // ─── ddb_list_library ─────────────────────────────────────────────────────────
 server.tool(
   "ddb_list_library",
-  "List all books and sourcebooks you own in your D&D Beyond library.",
+  "List all books you own in your D&D Beyond library, including sourcebooks, adventures, and supplements.",
   {},
   async () => {
     try {

--- a/src/tools/library.ts
+++ b/src/tools/library.ts
@@ -8,7 +8,7 @@ export async function listLibrary(context: BrowserContext): Promise<string> {
     throw new Error("Not logged in. Please run ddb_login first.");
   }
 
-  await page.goto("https://www.dndbeyond.com/en/library?type=sourcebooks&ownership=owned-shared", {
+  await page.goto("https://www.dndbeyond.com/en/library?ownership=owned-shared", {
     waitUntil: "networkidle",
     timeout: 30000,
   });


### PR DESCRIPTION
## Summary

The `ddb_list_library` tool was only returning sourcebooks because the library URL included a `type=sourcebooks` filter parameter. This meant adventures, supplements, and other book types were excluded from the results.

**Changes:**
- Removed the `type=sourcebooks` query parameter from the library URL so all owned/shared content is returned
- Updated the tool description to clarify that all book types (sourcebooks, adventures, supplements) are included

## Test plan
- [ ] Run `ddb_list_library` and verify that adventures and supplements appear in the results alongside sourcebooks
- [ ] Confirm sourcebooks still appear as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)